### PR TITLE
option to read credentials from env variables

### DIFF
--- a/pytest_testrail/conftest.py
+++ b/pytest_testrail/conftest.py
@@ -1,4 +1,5 @@
 import configparser
+import os
 from configparser import NoOptionError
 
 from .plugin import TestRailPlugin
@@ -31,8 +32,8 @@ def pytest_configure(config):
     if config.option.testrail:
         cfg_file = read_config_file(config.getoption("--testrail"))
         client = APIClient(cfg_file.get('API', 'url'))
-        client.user = cfg_file.get('API', 'email')
-        client.password = cfg_file.get('API', 'password', raw=True)
+        client.user = cfg_file.get('API', 'email', fallback=os.getenv('TESTRAIL_EMAIL'))
+        client.password = cfg_file.get('API', 'password', raw=True, fallback=os.getenv('TESTRAIL_PASSWORD'))
         ssl_cert_check = True
         tr_name = config.getoption('--tr_name')
 


### PR DESCRIPTION
### Summary
Allow the testrail username and password to be passed in via environment variables. This allows us to check in the testrail cfg file to github, and pass these parameters in at runtime.