### PR TITLE
DATA-3830: Fix parameterized test suite runs

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -227,7 +227,7 @@ class TestRailPlugin(object):
             if suite_id not in self.results:
                 self.results[suite_id] = []
             # handle parameterized tests where a prior parameter caused the test to fail
-            if not PYTEST_TO_TESTRAIL_STATUS['failed'] in (d['status_id'] for d in self.results[suite_id]):
+            if not PYTEST_TO_TESTRAIL_STATUS['failed'] in (d['status_id'] for d in self.results[suite_id] if d['case_id'] == test_id):
                 self.results[suite_id].append(data)
 
     def create_test_run(

--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -226,7 +226,9 @@ class TestRailPlugin(object):
             }
             if suite_id not in self.results:
                 self.results[suite_id] = []
-            self.results[suite_id].append(data)
+            # handle parameterized tests where a prior parameter caused the test to fail
+            if not PYTEST_TO_TESTRAIL_STATUS['failed'] in (d['status_id'] for d in self.results[suite_id]):
+                self.results[suite_id].append(data)
 
     def create_test_run(
             self, assign_user_id, project_id, suite_id, testrun_name, tr_keys):


### PR DESCRIPTION
### Summary
If a pytest parameterized test is run, and one of the iterations fails but any other following test passes, the last test status is used. This means failures are silently overwritten. This PR produces the correct behavior, in that if any parameter fails, the entire test case will be marked as failed.

### Bug Fixes/New Features
* If one test parameter fails, the entire test case fails

### How to Verify

### Side Effects

### Resolves

### Tests

### Code Reviewer(s)
