### PR TITLE
Fix create_test_plan - change include_all to False

### DIFF
--- a/pytest_testrail/plugin.py
+++ b/pytest_testrail/plugin.py
@@ -272,7 +272,7 @@ class TestRailPlugin(object):
             e = {
                 "suite_id": id,
                 "assignedto_id": assign_user_id,
-                "include_all": True,
+                "include_all": False,
                 "case_ids": suites_and_cases[id],
             }
             entries.append(e)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     name='pytest-testrail',
     description='pytest plugin for creating TestRail runs and adding results',
     long_description=long_description,
-    version='0.0.12',
+    version='0.0.13',
     author='Allan Kilpatrick',
     author_email='allanklp@gmail.com',
     url='http://github.com/allankilpatrick/pytest-testrail/',


### PR DESCRIPTION
* this might fix the issue of create_test_plan - not to include all test cases by default.
* bump version to 0.0.13